### PR TITLE
tmp-path: update to make boot happy

### DIFF
--- a/src/mathias/boot_sassc.clj
+++ b/src/mathias/boot_sassc.clj
@@ -98,8 +98,8 @@
         (util/dbug "Compiling %d changed SASS files... .\n" (count sass-files))
         (.mkdirs output-dir)
         (doseq [file sass-files]
-          (util/info "Compiling %s\n" (core/tmppath file))
-          (sassc (core/tmpfile file)
+          (util/info "Compiling %s\n" (core/tmp-path file))
+          (sassc (core/tmp-file file)
                  output-dir
                  :output-style output-style
                  :line-numbers line-numbers


### PR DESCRIPTION
removes all the `tmppath was deprecated, please use tmp-path instead` warnings
